### PR TITLE
chore: normalize line endings by specifying LF in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Description
Prevent having a mix of line endings in the project. Currently the project uses Windows' line ending `CRLF`, and this changes it to Linux line endings `LF`.

## How
I followed [this](https://stackoverflow.com/questions/15641259/how-to-normalize-working-tree-line-endings-in-git) answer about how to normalize a project and change all `CRLF` to `LF`.

## Reason
Besides the benefit from standardizing line endings, I was trying to run Mneme tests (using `mix test`) and got multiple test errors that got fixed by standardizing the line endings:

![Screenshot 2023-04-06 210640](https://user-images.githubusercontent.com/22730222/230527362-88262b60-f14a-451d-9bee-76d77d68cac1.png)
---
![Screenshot 2023-04-06 210956](https://user-images.githubusercontent.com/22730222/230527364-c4a22f5b-5178-4e0a-b0ac-09cdd6fdc07c.png)
---

## Notes
I am using Windows' WSL Ubuntu 22.04.2 LTS
