### PR TITLE
Raise a helpful error if mneme was not started

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,3 +93,5 @@ jobs:
       - run: mix deps.compile
 
       - run: mix test
+
+      - run: mix test.mneme_not_started

--- a/lib/mneme/options.ex
+++ b/lib/mneme/options.ex
@@ -215,7 +215,7 @@ defmodule Mneme.Options do
     |> collect_attributes(Map.get(attrs, @test_attr, []))
     |> collect_attributes(Map.get(attrs, @describe_attr, []))
     |> collect_attributes(Map.get(attrs, @module_attr, []))
-    |> collect_attributes([:persistent_term.get(@config_cache)])
+    |> collect_attributes([persistent_term_get!(@config_cache)])
   end
 
   defp collect_attributes(_), do: %{}
@@ -239,5 +239,12 @@ defmodule Mneme.Options do
       |> Map.new()
 
     Map.merge(acc, new, fn _, vs1, vs2 -> vs1 ++ vs2 end)
+  end
+
+  defp persistent_term_get!(key) do
+    :persistent_term.get(key)
+  rescue
+    ArgumentError ->
+      raise "Config key not found (#{inspect(@config_cache)}). Did you start Mneme in test_helper.exs?"
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -76,6 +76,10 @@ defmodule Mneme.MixProject do
       "coveralls.html": [
         &export_integration_coverage/1,
         "coveralls.html --import-cover cover"
+      ],
+      "test.mneme_not_started": [
+        fn _ -> System.put_env("START_MNEME", "false") end,
+        "test --only mneme_not_started test/mneme_not_started_test.exs"
       ]
     ]
   end
@@ -83,7 +87,8 @@ defmodule Mneme.MixProject do
   defp preferred_cli_env do
     [
       coveralls: :test,
-      "coveralls.html": :test
+      "coveralls.html": :test,
+      "test.mneme_not_started": :test
     ]
   end
 

--- a/test/mneme_not_started_test.exs
+++ b/test/mneme_not_started_test.exs
@@ -1,0 +1,22 @@
+defmodule Mneme.MnemeNotStartedTest do
+  use ExUnit.Case
+  use Mneme
+
+  @tag :mneme_not_started
+  test "error" do
+    assert_raise RuntimeError, ~r/Did you start Mneme/, fn ->
+      code = """
+      defmodule Mneme.StartedTest.ExampleTest do
+        use ExUnit.Case
+        use Mneme
+
+        test "a test" do
+          auto_assert 2 + 2
+        end
+      end
+      """
+
+      assert [{_, _}] = Code.compile_string(code)
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,5 @@
-ExUnit.start()
-Mneme.start()
+ExUnit.start(exclude: [mneme_not_started: true])
+
+if System.get_env("START_MNEME") != "false" do
+  Mneme.start()
+end


### PR DESCRIPTION
First off thanks for creating Mneme! It's a really neat library! :tada:

The first time I tried Mneme I went through the installation instructions a little _too_ fast and missed the `test_helper.exs` instruction which then resulted in a cryptic error:
```
== Compilation error in file test/mix_lock_parser_test.exs ==
** (ArgumentError) errors were found at the given arguments:

  * 1st argument: no persistent term stored with this key

    :persistent_term.get({Mneme.Options, :config_cache})
    (mneme 0.4.0) lib/mneme/options.ex:218: Mneme.Options.collect_attributes/1
    (mneme 0.4.0) lib/mneme/options.ex:175: Mneme.Options.options/1
    (mneme 0.4.0) lib/mneme.ex:320: Mneme.__build_assertion__/3
    (mneme 0.4.0) expanding macro: Mneme.auto_assert/1
    test/mix_lock_parser_test.exs:10: MixLockParserTest."test parses mix lock files"/1
```

With this change you instead get a tip to add mneme to your `test_helper.exs` file:

```
> mix test

== Compilation error in file test/mix_lock_parser_test.exs ==
** (RuntimeError) Config key not found ({Mneme.Options, :config_cache}). Did you start Mneme in test_helper.exs?
    (mneme 0.4.0) lib/mneme/options.ex:248: Mneme.Options.persistent_term_get!/1
    (mneme 0.4.0) lib/mneme/options.ex:218: Mneme.Options.collect_attributes/1
    (mneme 0.4.0) lib/mneme/options.ex:175: Mneme.Options.options/1
    (mneme 0.4.0) lib/mneme.ex:312: Mneme.__build_assertion__/3
    (mneme 0.4.0) expanding macro: Mneme.auto_assert/1
    test/mix_lock_parser_test.exs:10: MixLockParserTest."test parses mix lock files"/1
```

The majority of the changes here are to add a way to test that the `auto_assert` function raises this compile-time error, it's a little difficult because Mneme's `test_helper.exs` had `Mneme.start()`.

Although I'm also wondering if there is a reason to not have mneme auto-start by adding a `mod` entry in `application`? I suppose it's for the iex-based testing flows?