### PR TITLE
Update installation instructions to instruct users to add mneme in `:dev` environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ elixir tour_mneme.exs
     ```elixir
     defp deps do
       [
-        {:mneme, ">= 0.0.0", only: :test}
+        {:mneme, ">= 0.0.0", only: [:dev, :test]}
       ]
     end
     ```


### PR DESCRIPTION
Without this change `mix format` will fail:
> $ mix format
> ** (Mix) Unknown dependency :mneme given to :import_deps in the formatter configuration. Make sure the dependency is listed in your mix.exs and you have run "mix deps.get"

This happens because `mix format` by default is run with `MIX_ENV=dev`