### PR TITLE
Expose variables from LHO of matches

### DIFF
--- a/lib/mneme.ex
+++ b/lib/mneme.ex
@@ -124,12 +124,6 @@ defmodule Mneme do
 
           auto_assert pid when is_pid(pid) <- self()
 
-    * Bindings created are only available inside guards, not outside the
-      assertion.
-
-          auto_assert pid when is_pid(pid) <- self()
-          pid # ERROR: pid is not bound
-
   """
   @doc section: :assertion
   defmacro _pattern <- _expression do

--- a/lib/mneme/assertion.ex
+++ b/lib/mneme/assertion.ex
@@ -195,7 +195,8 @@ defmodule Mneme.Assertion do
   defp has_var?(pattern, name, context), do: Enum.any?(pattern, &match?({^name, _, ^context}, &1))
 
   defp mark_as_generated(vars) do
-    for {name, meta, context} <- vars, do: {name, [generated: true] ++ meta, context}
+    for {name, meta, context} <- vars,
+        do: {:var!, meta, [{name, [generated: true] ++ meta, context}]}
   end
 
   @doc false

--- a/lib/mneme/errors.ex
+++ b/lib/mneme/errors.ex
@@ -26,21 +26,31 @@ end
 
 defmodule Mneme.UnboundVariableError do
   @moduledoc false
-  defexception [:vars, :result, :message]
+  defexception [:vars, :message]
 
   @impl true
   def message(%{message: nil} = exception) do
-    %{vars: vars, result: result} = exception
+    %{vars: vars} = exception
 
     """
-    The amended match obsoleted one or several of already bound variables
-      (#{inspect(vars)}) while adjusting for the result #{inspect(result)}.
+    Updated auto-assertion is missing at least one previously bound variable:
 
-    Please run test(s) again.
+        #{format_vars(vars)}
+
+    Re-run this test to ensure it still passes.
     """
   end
 
   def message(%{message: message}) do
     message
+  end
+
+  defp format_vars(vars) do
+    vars
+    |> Enum.map(fn
+      {name, _context} -> name
+      name -> name
+    end)
+    |> Enum.map_join(", ", &Atom.to_string/1)
   end
 end

--- a/lib/mneme/errors.ex
+++ b/lib/mneme/errors.ex
@@ -23,3 +23,24 @@ defmodule Mneme.InternalError do
     """
   end
 end
+
+defmodule Mneme.UnboundVariableError do
+  @moduledoc false
+  defexception [:vars, :result, :message]
+
+  @impl true
+  def message(%{message: nil} = exception) do
+    %{vars: vars, result: result} = exception
+
+    """
+    The amended match obsoleted one or several of already bound variables
+      (#{inspect(vars)}) while adjusting for the result #{inspect(result)}.
+
+    Please run test(s) again.
+    """
+  end
+
+  def message(%{message: message}) do
+    message
+  end
+end

--- a/lib/mneme/utils.ex
+++ b/lib/mneme/utils.ex
@@ -20,4 +20,108 @@ defmodule Mneme.Utils do
   defp occurrences(<<char, rest::binary>>, char, acc), do: occurrences(rest, char, acc + 1)
   defp occurrences(<<_, rest::binary>>, char, acc), do: occurrences(rest, char, acc)
   defp occurrences(<<>>, _char, acc), do: acc
+
+  @doc """
+  Macro expands an expression in a pattern match context.
+  """
+  @spec expand_pattern(Macro.t(), Macro.Env.t()) :: Macro.t()
+  def expand_pattern({:when, meta, [left, right]}, caller) do
+    left = do_expand_pattern(left, Macro.Env.to_match(caller))
+    right = do_expand_pattern(right, %{caller | context: :guard})
+    {:when, meta, [left, right]}
+  end
+
+  def expand_pattern(expr, caller) do
+    do_expand_pattern(expr, Macro.Env.to_match(caller))
+  end
+
+  defp do_expand_pattern({:quote, _, [_]} = expr, _caller), do: expr
+  defp do_expand_pattern({:quote, _, [_, _]} = expr, _caller), do: expr
+  defp do_expand_pattern({:__aliases__, _, _} = expr, caller), do: Macro.expand(expr, caller)
+
+  defp do_expand_pattern({:@, _, [{attribute, _, _}]}, caller) do
+    caller.module |> Module.get_attribute(attribute) |> Macro.escape()
+  end
+
+  defp do_expand_pattern({left, meta, right} = expr, caller) do
+    case Macro.expand(expr, caller) do
+      ^expr ->
+        {do_expand_pattern(left, caller), meta, do_expand_pattern(right, caller)}
+
+      {left, meta, right} ->
+        {do_expand_pattern(left, caller), [original: expr] ++ meta,
+         do_expand_pattern(right, caller)}
+
+      other ->
+        other
+    end
+  end
+
+  defp do_expand_pattern({left, right}, caller) do
+    {do_expand_pattern(left, caller), do_expand_pattern(right, caller)}
+  end
+
+  defp do_expand_pattern([_ | _] = list, caller) do
+    Enum.map(list, &do_expand_pattern(&1, caller))
+  end
+
+  defp do_expand_pattern(other, _caller), do: other
+
+  @doc """
+  Collects variables bound in the given pattern.
+  """
+  @spec collect_vars_from_pattern(Macro.t()) :: [var] when var: {atom(), Macro.metadata(), atom()}
+  def collect_vars_from_pattern({:when, _, [left, right]}) do
+    pattern = collect_vars_from_pattern(left)
+
+    vars =
+      for {name, _, context} = var <- collect_vars_from_pattern(right),
+          has_var?(pattern, name, context),
+          do: var
+
+    pattern ++ vars
+  end
+
+  def collect_vars_from_pattern(expr) do
+    expr
+    |> Macro.prewalk([], fn
+      {:"::", _, [left, right]}, acc ->
+        {[left], collect_vars_from_binary(right, acc)}
+
+      {skip, _, [_]}, acc when skip in [:^, :@, :quote] ->
+        {:ok, acc}
+
+      {skip, _, [_, _]}, acc when skip in [:quote] ->
+        {:ok, acc}
+
+      {:_, _, context}, acc when is_atom(context) ->
+        {:ok, acc}
+
+      {name, meta, context}, acc when is_atom(name) and is_atom(context) ->
+        {:ok, [{name, meta, context} | acc]}
+
+      node, acc ->
+        {node, acc}
+    end)
+    |> elem(1)
+  end
+
+  defp collect_vars_from_binary(right, original_acc) do
+    right
+    |> Macro.prewalk(original_acc, fn
+      {mode, _, [{name, meta, context}]}, acc
+      when is_atom(mode) and is_atom(name) and is_atom(context) ->
+        if has_var?(original_acc, name, context) do
+          {:ok, [{name, meta, context} | acc]}
+        else
+          {:ok, acc}
+        end
+
+      node, acc ->
+        {node, acc}
+    end)
+    |> elem(1)
+  end
+
+  defp has_var?(pattern, name, context), do: Enum.any?(pattern, &match?({^name, _, ^context}, &1))
 end

--- a/test/mneme/assertion_test.exs
+++ b/test/mneme/assertion_test.exs
@@ -73,6 +73,30 @@ defmodule Mneme.AssertionTest do
                     eval: "assert %{bar: 2, baz: 3, foo: 1} = value"
                   ] <- targets(ast3, value)
     end
+
+    test "exposing variables from match LHO" do
+      value = 42
+
+      ast = quote(do: auto_assert(foo <- 42))
+
+      auto_assert [
+                    mneme: "auto_assert 42 <- 42",
+                    ex_unit: "assert 42 = 42",
+                    eval: "assert 42 = value"
+                  ] <- targets(ast, value)
+
+      auto_assert foo <- 42
+      auto_assert 42 <- foo
+      auto_assert [1] ++ foo <- [1, 2, 3]
+      auto_assert [2, 3] <- foo
+      auto_assert <<foo::binary-size(3), _::binary>> <- "abc def"
+      auto_assert "abc" <- foo
+      auto_assert "abc " <> foo <- "abc def"
+      auto_assert "def" <- foo
+      pinned = [3]
+      auto_assert list when is_list(list) and length(list) == 3 <- [1, 2, 3]
+      auto_assert [1, 2 | ^pinned] <- list
+    end
   end
 
   describe "auto_assert_raise" do

--- a/test/mneme/assertion_test.exs
+++ b/test/mneme/assertion_test.exs
@@ -92,10 +92,9 @@ defmodule Mneme.AssertionTest do
       auto_assert <<foo::binary-size(3), _::binary>> <- "abc def"
       auto_assert "abc" <- foo
 
-      if Version.compare(System.version(), "1.16.0") in [:gt, :eq] do
-        auto_assert ^foo <> " " <> foo <- "abc def"
-        auto_assert "def" <- foo
-      end
+      # commented out until the support for 1.15 is dropped
+      # auto_assert ^foo <> " " <> foo <- "abc def"
+      # auto_assert "def" <- foo
 
       pinned = [3]
       auto_assert list when is_list(list) and length(list) == 3 <- [1, 2, 3]

--- a/test/mneme/assertion_test.exs
+++ b/test/mneme/assertion_test.exs
@@ -91,8 +91,11 @@ defmodule Mneme.AssertionTest do
       auto_assert [2, 3] <- foo
       auto_assert <<foo::binary-size(3), _::binary>> <- "abc def"
       auto_assert "abc" <- foo
-      auto_assert ^foo <> " " <> foo <- "abc def"
-      auto_assert "def" <- foo
+
+      if Version.compare(System.version(), "1.16.0") in [:gt, :eq] do
+        auto_assert ^foo <> " " <> foo <- "abc def"
+        auto_assert "def" <- foo
+      end
 
       pinned = [3]
       auto_assert list when is_list(list) and length(list) == 3 <- [1, 2, 3]

--- a/test/mneme/assertion_test.exs
+++ b/test/mneme/assertion_test.exs
@@ -96,8 +96,9 @@ defmodule Mneme.AssertionTest do
       pinned = [3]
       auto_assert list when is_list(list) and length(list) == 3 <- [1, 2, 3]
       auto_assert [1, 2 | ^pinned] <- list
-      auto_assert {e1, e2, e3} <- {1, 2, 3}
-      IO.inspect(e1: e1, e2: e2, e3: e3)
+      result = auto_assert {e1, e2, e3} <- {1, 2, 3}
+      auto_assert {1, 2, 3} <- result
+      IO.inspect(result: result, e1: e1, e2: e2, e3: e3)
 
       auto_assert %{x: x, y: 2} <- %{x: 1, y: 2}
       auto_assert 1 <- x

--- a/test/mneme/assertion_test.exs
+++ b/test/mneme/assertion_test.exs
@@ -93,19 +93,19 @@ defmodule Mneme.AssertionTest do
       auto_assert "abc" <- foo
       auto_assert ^foo <> " " <> foo <- "abc def"
       auto_assert "def" <- foo
+
       pinned = [3]
       auto_assert list when is_list(list) and length(list) == 3 <- [1, 2, 3]
       auto_assert [1, 2 | ^pinned] <- list
+
       result = auto_assert {e1, e2, e3} <- {1, 2, 3}
       auto_assert {1, 2, 3} <- result
-      IO.inspect(result: result, e1: e1, e2: e2, e3: e3)
 
       auto_assert %{x: x, y: 2} <- %{x: 1, y: 2}
       auto_assert 1 <- x
 
-      # auto_assert %{y: ^e1} <- %{y: 1}
-      # auto_assert %{x: nil} <- Map.put(%{}, :x, x)
-      # IO.inspect(x: x)
+      auto_assert %{x: ^e1} <- %{x: 1}
+      auto_assert %{y: 1} <- Map.put(%{}, :y, e1)
     end
   end
 

--- a/test/mneme/assertion_test.exs
+++ b/test/mneme/assertion_test.exs
@@ -91,11 +91,20 @@ defmodule Mneme.AssertionTest do
       auto_assert [2, 3] <- foo
       auto_assert <<foo::binary-size(3), _::binary>> <- "abc def"
       auto_assert "abc" <- foo
-      auto_assert "abc " <> foo <- "abc def"
+      auto_assert ^foo <> " " <> foo <- "abc def"
       auto_assert "def" <- foo
       pinned = [3]
       auto_assert list when is_list(list) and length(list) == 3 <- [1, 2, 3]
       auto_assert [1, 2 | ^pinned] <- list
+      auto_assert {e1, e2, e3} <- {1, 2, 3}
+      IO.inspect(e1: e1, e2: e2, e3: e3)
+
+      auto_assert %{x: x, y: 2} <- %{x: 1, y: 2}
+      auto_assert 1 <- x
+
+      # auto_assert %{y: ^e1} <- %{y: 1}
+      # auto_assert %{x: nil} <- Map.put(%{}, :x, x)
+      # IO.inspect(x: x)
     end
   end
 

--- a/test/mneme_test.exs
+++ b/test/mneme_test.exs
@@ -40,7 +40,7 @@ defmodule MnemeTest do
     test "existing correct assertions succeed" do
       assertion = Mneme.Assertion.new(quote(do: auto_assert(1 <- 1)), 1, context(__ENV__))
 
-      assert Mneme.Assertion.run(assertion, __ENV__, false)
+      assert Mneme.Assertion.run!(assertion, __ENV__, false)
     end
 
     test "existing incorrect assertions fail with an ExUnit.AssertionError" do
@@ -48,7 +48,7 @@ defmodule MnemeTest do
 
       assert capture_io(fn ->
                assert_raise ExUnit.AssertionError, fn ->
-                 Mneme.Assertion.run(assertion, __ENV__, false)
+                 Mneme.Assertion.run!(assertion, __ENV__, false)
                end
              end) =~ "Mneme is running in non-interactive mode."
     end
@@ -58,7 +58,7 @@ defmodule MnemeTest do
 
       assert capture_io(fn ->
                assert_raise Mneme.AssertionError, fn ->
-                 Mneme.Assertion.run(assertion, __ENV__, false)
+                 Mneme.Assertion.run!(assertion, __ENV__, false)
                end
              end) =~ "Mneme is running in non-interactive mode."
     end


### PR DESCRIPTION
First of all, thanks for the amazing library.

The only thing that bugged me while using it, was that after matching with `<-`, the variables in LHO get lost, unlike when using `ExUnit.Assertions.assert/1`.

```elixir
# ExUnit.Assertions.assert/1
assert foo = 42
assert 42 = foo # foo is kept in the context from the match above

# Mneme.auto_assert/1
auto_assert foo <- 42
foo # raises unknown variable foo
```

This PR fixes this behavior for simple `auto_assert _ <- _`. There is still room for improvement for other assertions. Still, I wanted to keep this PR as concise as possible, specifically considering that it’s already a bit bloated with helpers.

The excerpt from tests:
```elixir
      auto_assert foo <- 42
      auto_assert 42 <- foo # foo is known
      auto_assert [1] ++ foo <- [1, 2, 3] # foo is rebound
      auto_assert [2, 3] <- foo
      auto_assert <<foo::binary-size(3), _::binary>> <- "abc def"
      auto_assert "abc" <- foo
      auto_assert ^foo <> " " <> foo <- "abc def" # pinned and then rebound
```

The great source of inspiration for that was `ExUnit.Assertions` itself. 