### PR TITLE
fix(mneme.watch): ensure ex_unit application is started before accessing config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This format is based on [Keep a Changelog](https://keepachangelog.com) and this 
 ### Fixed
 
   * Don't simplify structs used as keys in maps ([#96](https://github.com/zachallaun/mneme/issues/96)).
+  * [mix mneme.watch] Ensure the `:ex_unit` application is started before accessing its application config ([#95](https://github.com/zachallaun/mneme/issues/95)).
 
 ## v0.9.2 (2024-10-14)
 

--- a/lib/mneme/watch/test_runner.ex
+++ b/lib/mneme/watch/test_runner.ex
@@ -80,6 +80,8 @@ defmodule Mneme.Watch.TestRunner do
 
   @impl GenServer
   def init(opts) do
+    {:ok, _} = Application.ensure_all_started(:ex_unit)
+
     impl = Keyword.fetch!(opts, :impl)
     args = Keyword.fetch!(opts, :cli_args)
     watch_opts = Keyword.fetch!(opts, :watch)


### PR DESCRIPTION
Closes #95.