### PR TITLE
Add mneme in dev environment also

### DIFF
--- a/lib/mix/tasks/mneme.install.ex
+++ b/lib/mix/tasks/mneme.install.ex
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.Mneme.Install do
       # An example invocation
       example: @example,
       # A list of environments that this should be installed in.
-      only: [:test],
+      only: [:dev, :test],
       # a list of positional arguments, i.e `[:file]`
       positional: [],
       # Other tasks your task composes using `Igniter.compose_task`, passing in the CLI argv


### PR DESCRIPTION
If mneme is not in the dev environment, then `mix format` will fail with:

```
> mix format
** (Mix) Unknown dependency :mneme given to :import_deps in the formatter configuration. Make sure the dependency is listed in your mix.exs for environment :dev and you have run "mix deps.get"
```

Note: this is the igniter equivalent of https://github.com/zachallaun/mneme/pull/51